### PR TITLE
chore(build): fast compile and enable Wayland

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=/usr/bin/mold"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
 [workspace]
 
 members = ["snake-game", "tetris"]
+
+[profile.dev]
+opt-level = 1
+
+[profile.dev.package."*"]
+opt-level = 3

--- a/snake-game/Cargo.toml
+++ b/snake-game/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.11.0"
+bevy = { version = "0.11.0", features = ["wayland"] }
 rand = "0.8.5"
-bevy_prototype_lyon = "0.9.0"
+serde = "1.0.152"


### PR DESCRIPTION
Fast compile from <https://bevyengine.org/learn/book/getting-started/setup/>
Requires dependencies: clang and mold